### PR TITLE
Ensures mermaid is loaded before initializing it

### DIFF
--- a/md_mermaid.py
+++ b/md_mermaid.py
@@ -67,8 +67,19 @@ class MermaidPreprocessor(Preprocessor):
 
         if is_mermaid:
             new_lines.append('')
-            #new_lines.append('<script src="https://cdn.rawgit.com/knsv/mermaid/0.5.8/dist/mermaid.min.js"></script>')
-            new_lines.append('<script>mermaid.initialize({startOnLoad:true});</script>')
+            # This will initialize mermaid renderer. It's done only when the HTML document is ready,
+            # to ensure the loading of mermaid.js file is finished.
+            new_lines.append('''<script>
+                    function initializeMermaid() {
+                        mermaid.initialize({startOnLoad:true})
+                    }
+            
+                    if (document.readyState === "complete" || document.readyState === "interactive") {
+                        setTimeout(initializeMermaid, 1);
+                    } else {
+                        document.addEventListener("DOMContentLoaded", initializeMermaid);
+                    }
+            </script>''')
 
         return new_lines
 


### PR DESCRIPTION
In a lot of HTML pages including the rendered markdown, the `<script>` tag to load .js files (including mermaid.js) are at the very end of the HTML document. Most of time AFTER the `<script>` block generated by md_mermaid, which call `mermaid.initialize`
In those cases, an JS error occurs within the browser, saying the `mermaid` object is unknown, as the .js file defining it is not yet loaded.

This PR wrapped the initialization of mermaid after the document has loaded, and the browser had the chance to load the mermaid.js file.

