### PR TITLE
Init local var 'old_line'

### DIFF
--- a/md_mermaid.py
+++ b/md_mermaid.py
@@ -26,6 +26,7 @@ MermaidRegex = re.compile(r"^(?P<mermaid_sign>[\~\`]){3}[\ \t]*[Mm]ermaid[\ \t]*
 
 class MermaidPreprocessor(Preprocessor):
     def run(self, lines):
+        old_line = ""
         new_lines = []
         mermaid_sign = ""
         m_start = None


### PR DESCRIPTION
This shall fix an error `local variable 'old_line' referenced before assignment` in a document where a mermaid code block starts right in the first line. Rare, but I needed this. ;)