### PR TITLE
Support latest markdown releases

### DIFF
--- a/md_mermaid.py
+++ b/md_mermaid.py
@@ -85,7 +85,7 @@ class MermaidPreprocessor(Preprocessor):
 class MermaidExtension(Extension):
     """ Add source code hilighting to markdown codeblocks. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add HilitePostprocessor to Markdown instance. """
         # Insert a preprocessor before ReferencePreprocessor
         md.preprocessors.register(MermaidPreprocessor(md), 'mermaid', 35)


### PR DESCRIPTION
Fix code to support the latest Python-Markdown releases, which do no more require [md_globals](https://python-markdown.github.io/change_log/release-3.0/#md_globals-keyword-deprecated-from-extension-api) in `extendMarkdown`.