### PR TITLE
Remove deprecated md_globals and Show non-ascii characters

### DIFF
--- a/md_mermaid.py
+++ b/md_mermaid.py
@@ -85,7 +85,7 @@ class MermaidPreprocessor(Preprocessor):
 class MermaidExtension(Extension):
     """ Add source code hilighting to markdown codeblocks. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add HilitePostprocessor to Markdown instance. """
         # Insert a preprocessor before ReferencePreprocessor
         md.preprocessors.register(MermaidPreprocessor(md), 'mermaid', 35)

--- a/md_mermaid.py
+++ b/md_mermaid.py
@@ -36,9 +36,9 @@ class MermaidPreprocessor(Preprocessor):
         for line in lines:
             # Wait for starting line with MermaidRegex (~~~ or ``` following by [mM]ermaid )
             if not in_mermaid_code:
-                m_start = MermaidRegex.match(line)
+                m_start = MermaidRegex.match(strip_notprintable(line).strip())
             else:
-                m_end = re.match(r"^["+mermaid_sign+"]{3}[\ \t]*$", line)
+                m_end = re.match(r"^["+mermaid_sign+"]{3}[\ \t]*$", strip_notprintable(line).strip())
                 if m_end:
                     in_mermaid_code = False
 
@@ -57,7 +57,7 @@ class MermaidPreprocessor(Preprocessor):
                 new_lines.append("")
                 m_end = None
             elif in_mermaid_code:
-                new_lines.append(strip_notprintable(line).strip())
+                new_lines.append(line)
             else:
                 new_lines.append(line)
 


### PR DESCRIPTION
- Removed md_globals as it is no longer in use and throws an error
- Made non-ascii characters viewable
